### PR TITLE
shared hosting redirection issue fixed

### DIFF
--- a/_protected/frontend/controllers/SiteController.php
+++ b/_protected/frontend/controllers/SiteController.php
@@ -344,6 +344,6 @@ class SiteController extends Controller
         Yii::$app->session->setFlash('success', Yii::t('app', 'Success! You can now log in.').' '.
             Yii::t('app', 'Thank you').' '.Html::encode($user->username).' '.Yii::t('app', 'for joining us!'));
 
-        return $this->redirect('login');
+        return $this->redirect(['login']);
     }
 }


### PR DESCRIPTION
In shared hosting, after activation(success or not) the redirection line was return $this->redirect('login'); which was directly calling "http://hostname.com/path/login" as like pretty urls are ON. But if pretty Urls are OFF, this redirection causes 500 error. Changing the redirection code to return "return $this->redirect(['login']);" fixed the issue.
